### PR TITLE
Added response code check

### DIFF
--- a/lib/feed.js
+++ b/lib/feed.js
@@ -23,11 +23,13 @@ function parseURL(feedURL, options, callback) {
     if (u.protocol === 'http:' || u.protocol === 'https:') {
         //make sure to have a 30 second timeout
         var req = request(options, function (err, response, xml) {
-            if (err || xml === null) {
+            if (response.statusCode >= 400) {
+              callback("Failed to retrieve source! Invalid response code (" + response.statusCode +")!", null);
+            } else if (err || xml === null) {
                 if (err) {
                     callback(err, null);
                 } else {
-                    callback('failed to retrive source', null);
+                    callback('Failed to retrieve source!', null);
                 }
             } else {
                 parseString(xml, options, callback);


### PR DESCRIPTION
Error response codes (e.g. 404) made the code break in an unlovely way.
To address this, I added a response code check.
