### PR TITLE
Plain validation of response before checking statusCode.

### DIFF
--- a/lib/feed.js
+++ b/lib/feed.js
@@ -30,10 +30,14 @@ function parseURL(feedURL, options, callback) {
                     callback('Failed to retrieve source!', null);
                 }
             } else {
-                if ((typeof response !== "undefined" && response !== null ? response.statusCode : void 0) >= 400) {
+                if ((typeof response !== "undefined" && response !== null ? response.statusCode : void 0) != null) {
+                  if (response.statusCode >= 400) {
                     callback("Failed to retrieve source! Invalid response code (" + response.statusCode + ")!", null);
-                } else {
+                  } else {
                     parseString(xml, options, callback);
+                  }
+                } else {
+                  callback("Failed to retrieve source! No response code!!", null);
                 }
             }
         });


### PR DESCRIPTION
Prevent server crashing if response is undefined (could occur for some failing sources).
